### PR TITLE
attrC

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ selection.append('text')
 
 Comes in handy with the tspans..
 
-```js    f
+```js
 selection.append('text')
     .tspans(function(d) {
         return d3.wordwrap(text, 15);  // break line after 15 characters
@@ -51,7 +51,7 @@ svg.append(g).translate([margin.left, margin.top]);
 tick.translate(function(d) { return  [0, y(d)]; });
 ```
 
-### ƒ
+#### ƒ
 
 `ƒ` takes a string and returns a function that takes an object and returns whatever property the string is named. This clears away much of verbose `function(d){ return ... }` syntax in ECMAScript 5:
 
@@ -65,7 +65,7 @@ becomes
 x.domain(d3.extent(items, ƒ('price'));
 ```
 
-### attrC and styleC
+#### attrC and styleC
 `attrC` takes the name of an attribute and any number of functions, using the composition of the functions to map data bound to each element its attribute's value. 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ selection.append('text')
 
 Comes in handy with the tspans..
 
-```js
+```js    f
 selection.append('text')
     .tspans(function(d) {
         return d3.wordwrap(text, 15);  // break line after 15 characters
@@ -49,4 +49,31 @@ How I hated writing ``.attr('transform', function(d) { return 'translate()'; })`
 ```js
 svg.append(g).translate([margin.left, margin.top]);
 tick.translate(function(d) { return  [0, y(d)]; });
+```
+
+### ƒ
+
+`ƒ` takes a string and returns a function that takes an object and returns whatever property the string is named. This clears away much of verbose `function(d){ return ... }` syntax in ECMAScript 5:
+
+```js
+x.domain(d3.extent(items, function(d){ return d.price; }));
+```
+
+becomes 
+
+```js
+x.domain(d3.extent(items, ƒ('price'));
+```
+
+### attrC and styleC
+`attrC` takes the name of an attribute and any number of functions, using the composition of the functions to map data bound to each element its attribute's value. 
+
+```js
+circles.attrC('cx', x, ƒ('price'));
+```
+
+Instead of 
+
+```js
+circles.attrC('cx', function(d){ return x(d.price); });
 ```

--- a/d3-jetpack.js
+++ b/d3-jetpack.js
@@ -1,3 +1,5 @@
+function ƒ(str){ return function(d){ return typeof(str) == 'undefined' ? d : d[str] } } 
+
 (function() {
         
     function jetpack(d3) {
@@ -46,6 +48,20 @@
             });
             return n.attr ? s.attr(n.attr) : s;
         };
+
+        d3.selection.prototype.styleC = function(name){
+            return this.style(name, compose.apply(null, [].slice.call(arguments, 1)))
+        }
+        d3.selection.prototype.attrC = function(name){
+            return this.attr(name, compose.apply(null, [].slice.call(arguments, 1)))
+        }
+        d3.transition.prototype.styleC = function(name){
+            return this.style(name, compose.apply(null, [].slice.call(arguments, 1)))
+        }
+        d3.transition.prototype.attrC = function(name){
+            return this.attr(name, compose.apply(null, [].slice.call(arguments, 1)))
+        }
+
 
         var d3_parse_attributes_regex = /([\.#])/g;
 
@@ -113,6 +129,16 @@
                 return b[key] < a[key] ? -1 : b[key] > a[key] ? 1 : b[key] >= a[key] ? 0 : NaN;
             };
         };
+
+        function compose(){
+          var functions = arguments 
+          return function(d){
+            var i = functions.length
+            while(i--) d = functions[i].call(this, d)
+            return d
+          }
+        }
+
     }
 
     if (typeof d3 === 'object' && d3.version) jetpack(d3);


### PR DESCRIPTION
This has bigger changes with even worse syntax - happy to just leave it on my fork.

Monkey patching `attr` and `style` instead of creating new functions would be nicer. Unfortunately `style` takes an optional third argument for `!important`, so that's not possible without breaking the current API. 

Thanks again for all the great helper functions and apologies about ambushing you with ideas at 61 Locale. 