### PR TITLE
select_or_append

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,6 @@ d3-jetpack is a set of nifty convenience wrappers that speed up your daily work 
 
 Here's what's in the package:
 
-#### selection.select_or_append
-
-Selects the matching object or appends it as a child, will return as a selection.
-
-Exists to prevent double appending (appendation?) and easy updating of attributes when running a function multiple times. Given that it both selects and creates objects, you must declare the type of element (g, div, text, etc.) in addition to the typical class/id selector. 
-
-```js
-selection.select_or_append("div.my-class");
-d3.select('svg').select_or_append("g#someId");
-d3.select_or_append("div#someId");
-
-```
-
 
 #### selection.append / selection.insert
 
@@ -100,3 +87,16 @@ var firstY = polygons.map(ƒ('points', 0, 'y'));
 ```
 
 If you don't know how to type ƒ (it's [alt] + f on Macs), you can use ``d3.f()``, too. Also, [in @1wheel's blog](http://roadtolarissa.com/blog/2014/06/23/even-fewer-lamdas-with-d3/) you can read more about the rationale behind ƒ.
+
+#### selection.select_or_append
+
+Selects the matching object or appends it as a child, will return as a selection.
+
+Does away with ungainly "check to see if element exists, if not, append it." Must declare the type of element (g, div, text, etc.) in addition to the typical class/id selector. 
+
+```js
+selection.select_or_append("div.my-class");
+d3.select('svg').select_or_append("g#someId");
+d3.select_or_append("div#someId");
+
+```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Here's what's in the package:
 
 #### selection.select_or_append
 
-Selects the matching object or appends it as a child, will return as a selection
+Selects the matching object or appends it as a child, will return as a selection.
+
 Exists to prevent double appending (appendation?) and easy updating of attributes when running a function multiple times. Given that it both selects and creates objects, you must declare the type of element (g, div, text, etc.) in addition to the typical class/id selector. 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Exists to prevent double appending (appendation?) and easy updating of attribute
 
 ```js
 selection.select_or_append("div.my-class");
-selection.select_or_append("g#someId");
+d3.select('svg').select_or_append("g#someId");
 d3.select_or_append("div#someId");
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ selection.append("div#someId.some-class");
 selection.insert("div.my-class");
 ```
 
+
+#### selection.select_or_append
+
+Inspired by Django's QuerySet command get_or_create(), select_or_append selects the appropriate object or appends it as a child.
+Exists to prevent double appending (appendation?) and easy updating of attributes when running a function multiple times. Shallowly tested, just started using it in development.
+
+```js
+selection.select_or_append("div.my-class");
+selection.select_or_append("g#someId");
+d3.select_or_append("div#someId");
+
+```
+
 #### selection.tspans
 
 For multi-line SVG text

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@ d3-jetpack is a set of nifty convenience wrappers that speed up your daily work 
 
 Here's what's in the package:
 
+#### selection.select_or_append
+
+Selects the matching object or appends it as a child, will return as a selection
+Exists to prevent double appending (appendation?) and easy updating of attributes when running a function multiple times. Given that it both selects and creates objects, you must declare the type of element (g, div, text, etc.) in addition to the typical class/id selector. 
+
+```js
+selection.select_or_append("div.my-class");
+d3.select('svg').select_or_append("g#someId");
+d3.select_or_append("div#someId");
+
+```
+
+
 #### selection.append / selection.insert
 
 Appending and inserting with classes/ids 
@@ -17,19 +30,6 @@ selection.append("div#someId.some-class");
 
 // works with insert, too
 selection.insert("div.my-class");
-```
-
-
-#### selection.select_or_append
-
-Inspired by Django's QuerySet command get_or_create(), select_or_append selects the appropriate object or appends it as a child.
-Exists to prevent double appending (appendation?) and easy updating of attributes when running a function multiple times. Shallowly tested, just started using it in development.
-
-```js
-selection.select_or_append("div.my-class");
-d3.select('svg').select_or_append("g#someId");
-d3.select_or_append("div#someId");
-
 ```
 
 #### selection.tspans

--- a/d3-jetpack.js
+++ b/d3-jetpack.js
@@ -6,7 +6,7 @@
                 return 'translate('+[typeof xy == 'function' ? xy(d,i) : xy]+')';
             });
         };
-
+        
         d3.transition.prototype.translate = function(xy) {
             return this.attr('transform', function(d,i) {
                 return 'translate('+[typeof xy == 'function' ? xy(d,i) : xy]+')';
@@ -22,7 +22,6 @@
                 .attr('x', 0)
                 .attr('dy', function(d,i) { return i ? lh || 15 : 0; });
         };
-
         d3.selection.prototype.append = 
         d3.selection.enter.prototype.append = function(name) {
             var n = d3_parse_attributes(name), s;
@@ -46,6 +45,22 @@
             });
             return n.attr ? s.attr(n.attr) : s;
         };
+
+        d3.select_or_append = 
+        d3.selection.prototype.select_or_append =
+        d3.selection.enter.prototype.select_or_append = function(name) {
+            var n = d3_parse_attributes(name), s;
+            name = n.attr ? n.tag : name;
+            if (!this.select(name).empty()) {
+                return this.select(name)
+            } else {
+                name = d3_selection_creator(name);
+                s = this.select(function() {
+                return this.appendChild(name.apply(this, arguments));
+            });
+            }
+            return n.attr ? s.attr(n.attr) : s;
+        }
 
         var d3_parse_attributes_regex = /([\.#])/g;
 
@@ -77,6 +92,7 @@
             };
         }
 
+        
         d3.wordwrap = function(line, maxCharactersPerLine) {
             var w = line.split(' '),
                 lines = [],

--- a/d3-jetpack.js
+++ b/d3-jetpack.js
@@ -6,7 +6,7 @@
                 return 'translate('+[typeof xy == 'function' ? xy(d,i) : xy]+')';
             });
         };
-        
+
         d3.transition.prototype.translate = function(xy) {
             return this.attr('transform', function(d,i) {
                 return 'translate('+[typeof xy == 'function' ? xy(d,i) : xy]+')';
@@ -33,35 +33,34 @@
             });
             return n.attr ? s.attr(n.attr) : s;
         };
-
         d3.selection.prototype.insert = 
         d3.selection.enter.prototype.insert = function(name, before) {
             var n = d3_parse_attributes(name), s;
             name = n.attr ? n.tag : name;
+            console.log(name)
             name = d3_selection_creator(name);
+            console.log(name)
             before = d3_selection_selector(before);
             s = this.select(function() {
                 return this.insertBefore(name.apply(this, arguments), before.apply(this, arguments) || null);
             });
             return n.attr ? s.attr(n.attr) : s;
         };
-
         d3.select_or_append = 
         d3.selection.prototype.select_or_append =
         d3.selection.enter.prototype.select_or_append = function(name) {
-            var n = d3_parse_attributes(name), s;
-            name = n.attr ? n.tag : name;
-            if (!this.select(name).empty()) {
-                return this.select(name)
-            } else {
+            if (this.select(name).empty()) {
+                var n = d3_parse_attributes(name), s;
+                //console.log(name, n);
+                name = n.attr ? n.tag : name;
                 name = d3_selection_creator(name);
                 s = this.select(function() {
-                return this.appendChild(name.apply(this, arguments));
-            });
+                    return this.appendChild(name.apply(this, arguments));
+                });
+                return n.attr ? s.attr(n.attr) : s;
             }
-            return n.attr ? s.attr(n.attr) : s;
+            return this.select(name)
         }
-
         var d3_parse_attributes_regex = /([\.#])/g;
 
         function d3_parse_attributes(name) {
@@ -85,14 +84,15 @@
                 return this.ownerDocument.createElementNS(this.namespaceURI, name);
             };
         }
-
         function d3_selection_selector(selector) {
             return typeof selector === "function" ? selector : function() {
+                console.log('shit')
+                console.log(this)
+                console.log(selector)
                 return this.querySelector(selector);
             };
         }
 
-        
         d3.wordwrap = function(line, maxCharactersPerLine) {
             var w = line.split(' '),
                 lines = [],

--- a/d3-jetpack.js
+++ b/d3-jetpack.js
@@ -22,6 +22,7 @@
                 .attr('x', 0)
                 .attr('dy', function(d,i) { return i ? lh || 15 : 0; });
         };
+
         d3.selection.prototype.append = 
         d3.selection.enter.prototype.append = function(name) {
             var n = d3_parse_attributes(name), s;
@@ -37,9 +38,7 @@
         d3.selection.enter.prototype.insert = function(name, before) {
             var n = d3_parse_attributes(name), s;
             name = n.attr ? n.tag : name;
-            console.log(name)
             name = d3_selection_creator(name);
-            console.log(name)
             before = d3_selection_selector(before);
             s = this.select(function() {
                 return this.insertBefore(name.apply(this, arguments), before.apply(this, arguments) || null);
@@ -51,7 +50,6 @@
         d3.selection.enter.prototype.select_or_append = function(name) {
             if (this.select(name).empty()) {
                 var n = d3_parse_attributes(name), s;
-                //console.log(name, n);
                 name = n.attr ? n.tag : name;
                 name = d3_selection_creator(name);
                 s = this.select(function() {
@@ -86,9 +84,6 @@
         }
         function d3_selection_selector(selector) {
             return typeof selector === "function" ? selector : function() {
-                console.log('shit')
-                console.log(this)
-                console.log(selector)
                 return this.querySelector(selector);
             };
         }


### PR DESCRIPTION
Adds select_or_append, which selects a d3 selection if it exists, and otherwise appends it and then selects it. Big help on stepper-ish graphics.

---
#### selection.select_or_append

Selects the matching object or appends it as a child, will return as a selection.

Does away with ungainly "check to see if element exists, if not, append it." Must declare the type of element (g, div, text, etc.) in addition to the typical class/id selector. 

``` js
selection.select_or_append("div.my-class");
d3.select('svg').select_or_append("g#someId");
d3.select_or_append("div#someId");

```
