### PR TITLE
Fix syntax error in README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ jetpack lets you set the same listener for multiple events at once, jQuery style
 
 ```js
 selection.on('click touchend', function() {
-    console.log('this works on desktop AND mobile!')'
+    console.log('this works on desktop AND mobile!');
 });
 ```
 


### PR DESCRIPTION
I noticed a syntax highlighting error in the README, so fixed the typo where a ' should have been a ; .
