### PR TITLE
if ƒ encounters a function, it will call it

### DIFF
--- a/d3-jetpack.js
+++ b/d3-jetpack.js
@@ -127,7 +127,9 @@
         var i = 0, l = functions.length;
         while (i < l) {
             if (typeof(functions[i]) === 'string' || typeof(functions[i]) === 'number'){
-                functions[i] = (function(str){ return function(d){ return d[str] }; })(functions[i])
+                functions[i] = (function(str){ return function(d){ return typeof(d[str]) == 'function' ? d[str]() : d[str]; }; })(functions[i]);
+            } else if (typeof(functions[i]) === 'object'){
+                functions[i] = (function(map){ return function(d){ return typeof(map[d]) == 'function' ? map[d]() : map[d]; }; })(functions[i]);
             }
             i++;
         }


### PR DESCRIPTION
this way we can use ƒ with accessor functions..

example:

``` js
var scales = [d3.scale.linear(), d3.scale.linear().domain([0,100])];

console.log(scales.map(ƒ('domain', 1))); // logs [1, 100]
```

the prior behavior was to just return the function itself which would make the example use case impossible..
