### PR TITLE
flows tooltip to the top, unless it overflows viewport and there's space below cursor to accommodate tooltip

### DIFF
--- a/build/d3-jetpack.js
+++ b/build/d3-jetpack.js
@@ -333,7 +333,7 @@ var attachTooltip = function(sel, tooltipSel, fieldFns){
         y = e.clientY,
         bb = tooltipSel.node().getBoundingClientRect(),
         left = clamp(20, (x-bb.width/2), window.innerWidth - bb.width - 20),
-        top = innerHeight - y > 200 ? y + 20 : y - bb.height - 20;
+        top = innerHeight - y - 20 > Math.max(bb.height, 200) ? y + 20 : y - bb.height - 20;
 
     tooltipSel
       .style('left', left +'px')

--- a/build/d3-jetpack.js
+++ b/build/d3-jetpack.js
@@ -333,7 +333,7 @@ var attachTooltip = function(sel, tooltipSel, fieldFns){
         y = e.clientY,
         bb = tooltipSel.node().getBoundingClientRect(),
         left = clamp(20, (x-bb.width/2), window.innerWidth - bb.width - 20),
-        top = innerHeight - y - 20 > Math.max(bb.height, 200) ? y + 20 : y - bb.height - 20;
+        top = innerHeight - y - 20 > bb.height ? y + 20 : y - bb.height - 20;
 
     tooltipSel
       .style('left', left +'px')

--- a/src/attachTooltip.js
+++ b/src/attachTooltip.js
@@ -42,7 +42,7 @@ export default function(sel, tooltipSel, fieldFns){
         y = e.clientY,
         bb = tooltipSel.node().getBoundingClientRect(),
         left = clamp(20, (x-bb.width/2), window.innerWidth - bb.width - 20),
-        top = innerHeight - y - 20 > Math.max(bb.height, 200) ? y + 20 : y - bb.height - 20;
+        top = innerHeight - y - 20 > bb.height ? y + 20 : y - bb.height - 20
 
     tooltipSel
       .style('left', left +'px')


### PR DESCRIPTION
- addresses https://github.com/gka/d3-jetpack/issues/39

- not committing `./build/d3v4+jetpack.js`, because it seems to have been built with `d3@4.7.3`, while the current d3v4 is a bit ahead (`v4.10.2`).