### PR TITLE
Add support for objects in the f function

### DIFF
--- a/src/f.js
+++ b/src/f.js
@@ -6,6 +6,8 @@ function f(){
   while (i < l) {
     if (typeof(functions[i]) === 'string' || typeof(functions[i]) === 'number'){
       functions[i] = (function(str){ return function(d){ return d[str]; }; })(functions[i]);
+    } else if (typeof(functions[i]) === 'object'){
+      functions[i] = (function(obj){ return function(d){ return obj[d]; }; })(functions[i]);
     }
     i++;
   }

--- a/test/test-f.js
+++ b/test/test-f.js
@@ -24,3 +24,8 @@ tape('function are composed', function(test) {
   test.equal(ƒ(addOne, addOne)(10) , 12);
   test.end();
 });
+
+tape('objects are passed the accumulated value', function (test) {
+  test.equal(ƒ({foo: 'bar'})('foo'), 'bar');
+  test.end();
+});


### PR DESCRIPTION
Often times, users might have a map as an object, and want to access a property on that object based on some other property in the data. This pr allows that to be easily composed using the `f` function. Through function composition, now users can chain accessing properties, to feeding those properties into other objects using a convenient shorthand.